### PR TITLE
Removing the master/slave words

### DIFF
--- a/it/stationery/migrations/0003_auto_20180829_1343.py
+++ b/it/stationery/migrations/0003_auto_20180829_1343.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='order_record_master',
+            name='order_record_main',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('date', models.DateField()),
@@ -21,11 +21,11 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='order_record_slave',
+            name='order_record_subordinate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('num', models.IntegerField()),
-                ('order_record_master', models.ForeignKey(on_delete=False, to='stationery.order_record_master')),
+                ('order_record_main', models.ForeignKey(on_delete=False, to='stationery.order_record_main')),
                 ('stationery', models.ForeignKey(on_delete=False, to='stationery.stationery')),
             ],
         ),

--- a/it/stationery/migrations/0004_auto_20180830_1302.py
+++ b/it/stationery/migrations/0004_auto_20180830_1302.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RenameField(
-            model_name='order_record_slave',
+            model_name='order_record_subordinate',
             old_name='num',
             new_name='order_num',
         ),

--- a/it/stationery/models.py
+++ b/it/stationery/models.py
@@ -18,13 +18,13 @@ class stationery(models.Model):
     def __str__(self):
         return self.name
 
-class order_record_master(models.Model):
+class order_record_main(models.Model):
     user_list = models.ForeignKey('deviceman.user_list',on_delete=False)
     date = models.DateField()
     order_status = models.CharField(max_length=40)
 
-class order_record_slave(models.Model):
-    order_record_master = models.ForeignKey('order_record_master',on_delete=False)
+class order_record_subordinate(models.Model):
+    order_record_main = models.ForeignKey('order_record_main',on_delete=False)
     stationery = models.ForeignKey('stationery',on_delete=False)
     order_num = models.IntegerField()
 

--- a/it/stationery/views.py
+++ b/it/stationery/views.py
@@ -1,6 +1,6 @@
 
 from django.shortcuts import render, redirect
-from stationery.models import stationery, stat_type, purchase,provider,order_record_master,order_record_slave
+from stationery.models import stationery, stat_type, purchase,provider,order_record_main,order_record_subordinate
 from django.db.models import Count, Sum
 from django.http import HttpResponseRedirect, HttpResponse
 from deviceman.models import user_list
@@ -19,7 +19,7 @@ def index(request):
     stats = stationery.objects.values_list('stat_type','stat_type__name').annotate(Count('stat_type'))
     print(stats.query)
     print(stats)
-    orders = order_record_master.objects.filter(order_status= 'submitted')
+    orders = order_record_main.objects.filter(order_status= 'submitted')
     return render(request,'stationery/stat_index.html', {'stats':stats ,'orders':orders})
 
 def stat_list(request):
@@ -30,8 +30,8 @@ def stat_list(request):
 
 def order_detail(request):
     orderid=request.GET.get('orderid')
-    orders=order_record_slave.objects.filter(order_record_master_id=orderid)
-    users=order_record_master.objects.values('user_list_id').filter(id=orderid)
+    orders=order_record_subordinate.objects.filter(order_record_main_id=orderid)
+    users=order_record_main.objects.values('user_list_id').filter(id=orderid)
 
 
     userid=users[0]['user_list_id']
@@ -48,9 +48,9 @@ def stat_apply_index(request):
     if user_list_id==None:
         return HttpResponseRedirect('apply_login')
     #cart = request.session.get("cart", None)
-    #carts = order_record_master.objects.filter(user_list_id=user_list_id, order_status='submitted')
+    #carts = order_record_main.objects.filter(user_list_id=user_list_id, order_status='submitted')
     if request.method == 'GET':
-        stationerys=order_record_slave.objects.values('stationery__spec').annotate(number=Sum("order_num"),spec=F('stationery__spec'),id=F('stationery_id'), name=F('stationery__name')).order_by('-number')[:10]
+        stationerys=order_record_subordinate.objects.values('stationery__spec').annotate(number=Sum("order_num"),spec=F('stationery__spec'),id=F('stationery_id'), name=F('stationery__name')).order_by('-number')[:10]
         print(stationerys)
         return render(request, 'stationery/stat_apply_index.html', {'stationerys': stationerys})
         #return render(request, 'stationery/stat_apply_index.html', {'carts': carts,'stationerys':stationerys})
@@ -64,8 +64,8 @@ def add_to_cart(request):
     user_list_id=request.session.get('user_list_id',None)
     statid=request.GET.get('statid')
     #obj=models.order_record(stationery_id=20,user_list_id=243, num=1)
-    order_record_master.objects.create(order_status='submitted',user_list_id=243,date='2018-08-30')
-    order_record_slave.objects.create(order_num=1,order_record_master_id=3,stationery_id=12)
+    order_record_main.objects.create(order_status='submitted',user_list_id=243,date='2018-08-30')
+    order_record_subordinate.objects.create(order_num=1,order_record_main_id=3,stationery_id=12)
     #obj.save()
     #carts=order_record.objects.filter(user_list_id=243)
     #print(carts)
@@ -74,8 +74,8 @@ def add_to_cart(request):
 def clean_cart(request):
     user_list_id=request.session.get('user_list_id')
     orderid=request.session.get('orderid')
-    order_record_slave.objects.filter(order_record_master_id=orderid).delete()
-    #order_record_master.objects.filter(user_list_id=user_list_id, order_status='shopping').delete()
+    order_record_subordinate.objects.filter(order_record_main_id=orderid).delete()
+    #order_record_main.objects.filter(user_list_id=user_list_id, order_status='shopping').delete()
 
 
     return HttpResponseRedirect('stat_apply_index')
@@ -86,14 +86,14 @@ def submit_cart(request):
     print(user_list_id)
     print(orderid)
     #orderid=request.session.get('orderid')
-    order_record_master.objects.filter(user_list_id=user_list_id, id=orderid).update(order_status='submitted')
+    order_record_main.objects.filter(user_list_id=user_list_id, id=orderid).update(order_status='submitted')
     request.session['orderid']=''
     del request.session['user_list_id']
     return HttpResponseRedirect('apply_login')
 
 def complete_order(request):
     orderid=request.GET.get('orderid')
-    order_record_master.objects.filter(id=orderid).update(order_status='Completed')
+    order_record_main.objects.filter(id=orderid).update(order_status='Completed')
     return HttpResponseRedirect('index')
 
 @csrf_exempt
@@ -112,17 +112,17 @@ def apply_login(request):
             request.session['email_address']=email_address
             request.session['dept_name'] = user.dept_list.dept_name
 
-            order_record_masters=order_record_master.objects.filter(user_list_id=user.id, order_status='shopping')
-            if order_record_masters.exists():
-                for order in order_record_masters:
+            order_record_mains=order_record_main.objects.filter(user_list_id=user.id, order_status='shopping')
+            if order_record_mains.exists():
+                for order in order_record_mains:
                     request.session['orderid']=order.id   #如果有未提交的申请，取出ID号，传递给session
                     print(order.id)
 
             else:
                 # 如果没有查询到未提交的申请，就创建一条主记录
-                order_record_master.objects.create(date=datetime.datetime.now().strftime("%Y-%m-%d"), order_status='shopping',user_list_id=user.id)
+                order_record_main.objects.create(date=datetime.datetime.now().strftime("%Y-%m-%d"), order_status='shopping',user_list_id=user.id)
                 print(user.id)
-                orders=order_record_master.objects.filter(user_list_id=user.id, order_status='shopping')
+                orders=order_record_main.objects.filter(user_list_id=user.id, order_status='shopping')
                 print(orders)
                 for order in orders:
                     request.session['orderid']=order.id
@@ -142,25 +142,25 @@ def ajax(request):
     print("get the stationery id is '%s'"%(id))
     print("get order is is '%s'"%(orderid))
            #search if there is any same stationery_id on the shopping orderid
-    res=order_record_slave.objects.filter(order_record_master_id=orderid, stationery_id=id )
+    res=order_record_subordinate.objects.filter(order_record_main_id=orderid, stationery_id=id )
 
     if res.exists():
         print("find same stationery '%s'" % (id))
         for stat in res:
             id = stat.id
             print("stat id is '%s'"%(id))
-            obj=order_record_slave.objects.get(id=id)
+            obj=order_record_subordinate.objects.get(id=id)
             obj.order_num=obj.order_num+1
             obj.save()
-            stats = order_record_slave.objects.filter(order_record_master_id=orderid).values('stationery__name', 'order_num')
+            stats = order_record_subordinate.objects.filter(order_record_main_id=orderid).values('stationery__name', 'order_num')
             ret = list(stats)
             result = json.dumps(ret)
             return HttpResponse(result, "application/json")
     else:
         print("not found any same stationery")
-        order_record_slave.objects.create(order_num=1, order_record_master_id=orderid, stationery_id=id)
-        #stats=serializers.serialize('json',order_record_master.objects.filter(id=orderid))
-        stats= order_record_slave.objects.filter(order_record_master_id=orderid).values('stationery__name', 'order_num')
+        order_record_subordinate.objects.create(order_num=1, order_record_main_id=orderid, stationery_id=id)
+        #stats=serializers.serialize('json',order_record_main.objects.filter(id=orderid))
+        stats= order_record_subordinate.objects.filter(order_record_main_id=orderid).values('stationery__name', 'order_num')
         ret = list(stats)
         result = json.dumps(ret)
         return HttpResponse(result, "application/json")


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.